### PR TITLE
Add single-file responsive e-commerce demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CheapShop</title>
+<style>
+:root{
+  --primary:#ff5722;
+  --secondary:#ff4081;
+  --bg:#f7f7f7;
+}
+*{box-sizing:border-box;}
+body{margin:0;font-family:Arial,Helvetica,sans-serif;background:var(--bg);}
+header{position:sticky;top:0;z-index:10;display:flex;justify-content:space-between;align-items:center;background:var(--primary);color:#fff;padding:10px 20px;}
+header .logo{font-size:1.4em;font-weight:bold;}
+header button{background:var(--secondary);color:#fff;border:none;padding:8px 15px;border-radius:4px;font-size:1em;cursor:pointer;}
+.carousel{position:relative;overflow:hidden;height:180px;margin-bottom:10px;}
+.carousel .slides{display:flex;height:100%;transition:transform .5s ease;}
+.carousel img{width:100%;object-fit:cover;flex-shrink:0;}
+.filters{text-align:center;margin:10px 0;}
+.filters button{margin:5px;padding:8px 15px;border:none;border-radius:20px;background:#eee;cursor:pointer;}
+.filters button.active{background:var(--secondary);color:#fff;}
+.product-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:15px;padding:0 15px 60px;}
+.product{background:#fff;border-radius:8px;box-shadow:0 2px 5px rgba(0,0,0,0.1);padding:10px;display:flex;flex-direction:column;}
+.product img{width:100%;border-radius:8px;}
+.product h4{margin:10px 0 5px;font-size:1em;}
+.price{color:var(--primary);font-weight:bold;}
+.old-price{text-decoration:line-through;color:#999;font-size:.9em;margin-left:5px;}
+.product button{margin-top:auto;background:var(--primary);color:#fff;border:none;padding:10px;border-radius:4px;font-size:1em;cursor:pointer;}
+.cart{position:fixed;top:0;right:0;width:300px;height:100%;background:#fff;box-shadow:-2px 0 5px rgba(0,0,0,.2);transform:translateX(100%);transition:transform .3s ease;display:flex;flex-direction:column;padding:20px;z-index:20;}
+.cart.open{transform:translateX(0);}
+.cart h2{margin-top:0;}
+#cart-items{list-style:none;padding:0;margin:0;flex-grow:1;overflow:auto;}
+#cart-items li{display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;}
+#cart-items img{width:50px;height:50px;object-fit:cover;border-radius:4px;margin-right:10px;}
+#cart-items button{background:none;border:none;color:var(--secondary);font-size:1.2em;cursor:pointer;}
+.total{font-size:1.2em;font-weight:bold;margin-bottom:10px;}
+@media(max-width:600px){
+  header{flex-direction:column;align-items:flex-start;}
+  .carousel{height:150px;}
+  .product-grid{grid-template-columns:repeat(auto-fit,minmax(140px,1fr));}
+}
+</style>
+</head>
+<body>
+<header>
+  <div class="logo">CheapShop</div>
+  <button id="cart-btn">Carrello (<span id="cart-count">0</span>)</button>
+</header>
+<section class="carousel">
+  <div class="slides">
+    <img src="https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=1200&q=60" alt="offerta1">
+    <img src="https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=1200&q=60" alt="offerta2">
+    <img src="https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=1200&q=60" alt="offerta3">
+  </div>
+</section>
+<section class="filters">
+  <button data-filter="all" class="active">Tutti</button>
+  <button data-filter="fashion">Moda</button>
+  <button data-filter="electronics">Elettronica</button>
+  <button data-filter="beauty">Bellezza</button>
+  <button data-filter="home">Casa</button>
+  <button data-filter="toys">Giocattoli</button>
+</section>
+<section id="products" class="product-grid"></section>
+<div id="cart" class="cart">
+  <h2>Il tuo carrello</h2>
+  <ul id="cart-items"></ul>
+  <p class="total">Totale: €<span id="cart-total">0.00</span></p>
+  <button id="close-cart">Chiudi</button>
+</div>
+<script>
+const products=[
+  {id:1,name:"Sneakers Trend",price:39.99,discount:20,image:"https://images.unsplash.com/photo-1512436991641-6745cdb1723f?auto=format&fit=crop&w=600&q=60",category:"fashion"},
+  {id:2,name:"Casual Bag",price:29.99,discount:15,image:"https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=600&q=60",category:"fashion"},
+  {id:3,name:"Smart Watch",price:59.99,discount:25,image:"https://images.unsplash.com/photo-1513279920799-3de2e8f0e921?auto=format&fit=crop&w=600&q=60",category:"electronics"},
+  {id:4,name:"Denim Jacket",price:49.99,discount:30,image:"https://images.unsplash.com/photo-1503342217505-b0a15ec3261c?auto=format&fit=crop&w=600&q=60",category:"fashion"},
+  {id:5,name:"Matte Lipstick",price:9.99,discount:10,image:"https://images.unsplash.com/photo-1526045612212-70caf35c14df?auto=format&fit=crop&w=600&q=60",category:"beauty"},
+  {id:6,name:"Wireless Headphones",price:89.99,discount:35,image:"https://images.unsplash.com/photo-1512058564366-c9e3ca9b2f4b?auto=format&fit=crop&w=600&q=60",category:"electronics"},
+  {id:7,name:"Ceramic Mug",price:12.99,discount:5,image:"https://images.unsplash.com/photo-1498654896293-37aacf113fd9?auto=format&fit=crop&w=600&q=60",category:"home"},
+  {id:8,name:"Plush Bear",price:19.99,discount:40,image:"https://images.unsplash.com/photo-1601758123927-8a9f98dd81e4?auto=format&fit=crop&w=600&q=60",category:"toys"},
+  {id:9,name:"Soft Pillow",price:24.99,discount:20,image:"https://images.unsplash.com/photo-1505693416388-ac5ce068fe85?auto=format&fit=crop&w=600&q=60",category:"home"},
+  {id:10,name:"LED Lamp",price:34.99,discount:25,image:"https://images.unsplash.com/photo-1493666438817-866a91353ca9?auto=format&fit=crop&w=600&q=60",category:"home"},
+  {id:11,name:"Bluetooth Speaker",price:44.99,discount:30,image:"https://images.unsplash.com/photo-1518770660439-4636190af475?auto=format&fit=crop&w=600&q=60",category:"electronics"},
+  {id:12,name:"Makeup Kit",price:29.99,discount:15,image:"https://images.unsplash.com/photo-1522335789203-aabd1fc54bc9?auto=format&fit=crop&w=600&q=60",category:"beauty"}
+];
+let cart=[];
+function discounted(p){return p.price*(1-p.discount/100);} 
+function renderProducts(filter='all'){
+  const container=document.getElementById('products');
+  container.innerHTML='';
+  const list=filter==='all'?products:products.filter(p=>p.category===filter);
+  list.forEach(p=>{
+    const div=document.createElement('div');
+    div.className='product';
+    div.innerHTML=`<img src="${p.image}" alt="${p.name}">
+      <h4>${p.name}</h4>
+      <p><span class="price">€${discounted(p).toFixed(2)}</span><span class="old-price">€${p.price.toFixed(2)}</span></p>
+      <button data-id="${p.id}">Aggiungi al carrello</button>`;
+    container.appendChild(div);
+  });
+}
+renderProducts();
+
+document.getElementById('products').addEventListener('click',e=>{
+  if(e.target.tagName==='BUTTON'){
+    addToCart(parseInt(e.target.dataset.id));
+  }
+});
+function addToCart(id){
+  const item=cart.find(i=>i.id===id);
+  if(item){item.qty++;}else{cart.push({id,qty:1});}
+  updateCart();
+}
+function updateCart(){
+  const list=document.getElementById('cart-items');
+  list.innerHTML='';
+  let total=0;
+  cart.forEach(it=>{
+    const prod=products.find(p=>p.id===it.id);
+    const price=discounted(prod)*it.qty;
+    total+=price;
+    const li=document.createElement('li');
+    li.innerHTML=`<img src="${prod.image}" alt="">${prod.name} x${it.qty}<span>€${price.toFixed(2)}</span><button data-id="${it.id}">&times;</button>`;
+    list.appendChild(li);
+  });
+  document.getElementById('cart-total').textContent=total.toFixed(2);
+  document.getElementById('cart-count').textContent=cart.reduce((s,i)=>s+i.qty,0);
+}
+document.getElementById('cart-items').addEventListener('click',e=>{
+  if(e.target.tagName==='BUTTON'){
+    const id=parseInt(e.target.dataset.id);
+    cart=cart.filter(i=>i.id!==id);
+    updateCart();
+  }
+});
+const cartEl=document.getElementById('cart');
+document.getElementById('cart-btn').addEventListener('click',()=>cartEl.classList.add('open'));
+document.getElementById('close-cart').addEventListener('click',()=>cartEl.classList.remove('open'));
+
+document.querySelectorAll('.filters button').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    document.querySelector('.filters button.active').classList.remove('active');
+    btn.classList.add('active');
+    renderProducts(btn.dataset.filter);
+  });
+});
+const slides=document.querySelector('.carousel .slides');
+let current=0;
+setInterval(()=>{
+  current=(current+1)%slides.children.length;
+  slides.style.transform=`translateX(-${current*100}%)`;
+},3000);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` with a responsive single-page shop demo
- include carousel, product filters, and a client-side cart

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689de3d08ab8833280f02676cde46754